### PR TITLE
add us.kg

### DIFF
--- a/data/Domains.md
+++ b/data/Domains.md
@@ -9,3 +9,4 @@
 | [Obl.ong](https://obl.ong) | Free, quality subdomains for all, backed by our nonprofit. Get yourname.obl.ong and become a voting member in our organization today! | ✅ |
 | [Open Domains](https://open-domains.net) | Free subdomains for personal sites, open-source projects, and more. | ✅ |
 | [pp.ua](https://pp.ua) | Free pp.ua subdomains. | ✅ |
+| [us.kg](https://nic.us.kg) | Free subdomain service run by the nonprofit DigitalPlat Foundation, supported by the Hack Foundation. | ✅ |


### PR DESCRIPTION
US.KG is a free domain registration service run by the nonprofit DigitalPlat Foundation, supported by the Hack Foundation. Donations are used for nonprofit activities.

https://nic.us.kg