### PR TITLE
add NYC.mn

### DIFF
--- a/data/Domains.md
+++ b/data/Domains.md
@@ -6,6 +6,7 @@
 | [is-a.dev](https://www.is-a.dev) | Free is-a.dev subdomain for developers. | ✅ |
 | [is-a-good.dev](https://is-a-good.dev) | A free is-a-good-dev subdomain for developers. | ✅ |
 | [js.org](https://js.org) | Free js.org subdomains for GitHub Pages for the JavaScript community. | ✅ |
+| [NYC.mn](https://dot.nyc.mn) | Free subdomains for individuals and businesses related to New York City. New York City IP address required for application. | ✅ |
 | [Obl.ong](https://obl.ong) | Free, quality subdomains for all, backed by our nonprofit. Get yourname.obl.ong and become a voting member in our organization today! | ✅ |
 | [Open Domains](https://open-domains.net) | Free subdomains for personal sites, open-source projects, and more. | ✅ |
 | [pp.ua](https://pp.ua) | Free pp.ua subdomains. | ✅ |


### PR DESCRIPTION
However, be aware that NYC.mn

- Requires a New York City IP address for application.
- Does not allow temporary or alias email addresses (to avoid spams).
- Users must host a site on the domain, or it may be revoked.

Given these restrictions, unsure if this is acceptable to be merged in your list?

**Affiliation Disclosure: I'm one of the maintainers of this service.**