### PR TITLE
add FreeFlarum

### DIFF
--- a/data/APIs_Data_and_ML.md
+++ b/data/APIs_Data_and_ML.md
@@ -30,6 +30,7 @@
 | [DeepAR](https://developer.deepar.ai) | Augmented reality face filters for any platform with one SDK. Free plan provides up to 10 monthly active users (MAU) and tracking up to 4 faces. |
 | [Deepnote](https://deepnote.com) | A new kind of data science notebook. Jupyter-compatible with real-time collaboration and running in the cloud. Free tier includes unlimited personal projects, up to 750 hours of standard hardware, and teams with up to 3 editors. |
 | [Diggernaut](https://www.diggernaut.com) | Cloud-based web scraping and data extraction platform for turning any website into the dataset or to work with it as with an API. Free plan includes 5k page requests monthly. |
+| [FreeFlarum](https://freeflarum.com) | FreeFlarum is a free Flarum hosting service that allows users to quickly create and manage Flarum-based forums without the need for technical expertise or server management. |
 | [IP.City](https://ip.city) | 100 free IP geo-location requests per day. |
 | [Mockae](https://mockae.com/) | Fake REST API powered by Lua. |
 | [Scraper's Proxy](https://scrapersproxy.com) | Simple HTTP proxy API made for scraping. Scrape anonymously without having to worry about restrictions, blocks, or captchas. First 100 successful scrapes per month free including JavaScript rendering (more are available if you contact support). |


### PR DESCRIPTION
FreeFlarum is a free hosting service that allows users to quickly create and manage Flarum-based forums without the need for technical expertise or server management[1][2].

Citations:
[1] https://freeflarum.com
[2] https://freeflarum.com/support
[3] https://www.reddit.com/r/selfhosted/comments/13n32xs/flarum_a_delightful_open_source_modern_forum_v18/
[4] https://discuss.flarum.org/d/7585-free-flarum-hosting-on-an-expert-platform-by-freeflarum-com/4769
[5] https://discuss.flarum.org/d/7585-free-flarum-hosting-on-an-expert-platform-by-freeflarum-com/3876
[6] https://support.freeflarum.com
[7] https://discuss.flarum.org/d/31468-what-s-the-difference-between-flarum-freeflarum
[8] https://brandfetch.com/freeflarum.com