### PR TITLE
Add thedev.ovh to Domains directory

### DIFF
--- a/data/Domains.md
+++ b/data/Domains.md
@@ -13,3 +13,4 @@
 | [Open Host](https://registry.openhost.uk) | A free subdomain service offering subdomains on `prvcy.page`, `16-b.it`, `32-b.it`, `64-b.it` with PSL support, and on `pride.moe`, `pride.ngo` without PSL support. | ℹ️ `pride.moe` and `pride.ngo` are not listed, the rest are however. |
 | [pp.ua](https://pp.ua) | Free pp.ua subdomains. | ✅ |
 | [us.kg](https://nic.us.kg) | Free subdomain service run by the nonprofit DigitalPlat Foundation, supported by the Hack Foundation. | ✅ |
+| [thedev.ovh](https://thedev.ovh) | Free subdomain service for personal use, students, developers and non-commercial users, free one domain name | ✅ |

--- a/data/Domains.md
+++ b/data/Domains.md
@@ -13,4 +13,4 @@
 | [Open Host](https://registry.openhost.uk) | A free subdomain service offering subdomains on `prvcy.page`, `16-b.it`, `32-b.it`, `64-b.it` with PSL support, and on `pride.moe`, `pride.ngo` without PSL support. | ℹ️ `pride.moe` and `pride.ngo` are not listed, the rest are however. |
 | [pp.ua](https://pp.ua) | Free pp.ua subdomains. | ✅ |
 | [us.kg](https://nic.us.kg) | Free subdomain service run by the nonprofit DigitalPlat Foundation, supported by the Hack Foundation. | ✅ |
-| [thedev.ovh](https://thedev.ovh) | Free subdomain service for personal use, students, developers and non-commercial users, free one domain name | ✅ |
+| [thedev.ovh](https://thedev.ovh) | Free subdomain service for personal use, students, developers and non-commercial users, free one domain name for everyone! | ✅ |


### PR DESCRIPTION
thedev.ovh is a free domain name service (for one domain name), we provide everyone with quality subdomains with high investment and meticulousness. We invest our own money in the domain name, and carefully manage to avoid abuse. I represent the whole team to add the domain free.hrsn.dev so that people can know more about thedev.ovh. We will sell the second subdomain to users for $1. On behalf of thedev.ovh, thank you to free.hrsn.dev