### PR TITLE
Add Zone.ID to Domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ A massive list including a huge amount of products and services that are complet
 | [Open Host](https://registry.openhost.uk) | A free subdomain service offering subdomains on `prvcy.page`, `16-b.it`, `32-b.it`, `64-b.it`, `pride.moe` and `pride.ngo`. | ⚠️ `pride.moe` and `pride.ngo` are not listed. |
 | [pp.ua](https://pp.ua) | Free pp.ua subdomains. | ✅ |
 | [us.kg](https://nic.us.kg) | Free subdomain service run by the nonprofit DigitalPlat Foundation, supported by the Hack Foundation. | ✅ |
+| [Zone.ID](https://zone.id/) | Zone.ID is a premium subdomain provider as an alternative to the .id domain. Zone.ID is under the auspices of PT. Geksa | ✅ |
 
 <!-- Email.md -->
 ## Email


### PR DESCRIPTION
Subdomain provider as an alternative to the .id domain. I found it through Public Suffix, and it works.