### PR TITLE
Add calendar category & ChronoLink service

### DIFF
--- a/data/Calendar.md
+++ b/data/Calendar.md
@@ -1,0 +1,7 @@
+## Calendar
+
+| Website | Description |
+|:-:|-|
+| [Gmail](https://gmail.com) | Free personal email and calendar. |
+| [Outlook](https://outlook.com) | Free personal email and calendar. |
+| [Tutanota](https://tutanota.com) | An email service that prioritizes privacy. The free plan has restrictions such as a maximum of 1gb of storage, 1 calendar per account, and only 1 email per account with a 48 hour verification period to prevent abuse. |

--- a/data/Calendar.md
+++ b/data/Calendar.md
@@ -2,6 +2,7 @@
 
 | Website | Description |
 |:-:|-|
+| [ChronoLink](https://www.chronolink.app) | Flexibly synchronize calendars, create rules for selecting and transforming events. The free plan is restricted to one sync connection. |
 | [Gmail](https://gmail.com) | Free personal email and calendar. |
 | [Outlook](https://outlook.com) | Free personal email and calendar. |
 | [Tutanota](https://tutanota.com) | An email service that prioritizes privacy. The free plan has restrictions such as a maximum of 1gb of storage, 1 calendar per account, and only 1 email per account with a 48 hour verification period to prevent abuse. |

--- a/data/_start.md
+++ b/data/_start.md
@@ -14,6 +14,7 @@ A massive list including a huge amount of products and services that are complet
 - [APIs, Data & ML](#apis-data-and-ml)
 - [Artificial Intelligence](#artificial-intelligence)
 - [BaaS](#baas)
+- [Calendar](#calendar)
 - [Code Editors](#code-editors)
 - [Code Generation](#code-generation)
 - [Courses](#courses)


### PR DESCRIPTION
## Summary
- Add "Calendar" category for Gmail, Outlook & Tutanota (91586c7eb1b9c322962157d507dad38baf9a1210)
- Add ChronoLink service (a358e63206797c11ac61752ef172b131a97d8abc)

## Rationale
People looking for calendar services have an easier time finding the existing entries Gmail, Outlook and Tutanota when they are also listed in a "Calendar" category.

Also, the category is useful for calendar-related tools that have nothing to do with Email. One such service is ChronoLink, my own calendar synchronization service.