### PR TITLE
Add SoftVoyagers free API services

### DIFF
--- a/data/APIs_Data_and_ML.md
+++ b/data/APIs_Data_and_ML.md
@@ -30,13 +30,21 @@
 | [Deepnote](https://deepnote.com) | A new kind of data science notebook. Jupyter-compatible with real-time collaboration and running in the cloud. Free tier includes unlimited personal projects, up to 750 hours of standard hardware, and teams with up to 3 editors. |
 | [Diggernaut](https://www.diggernaut.com) | Cloud-based web scraping and data extraction platform for turning any website into the dataset or to work with it as with an API. Free plan includes 5k page requests monthly. |
 | [ExtendsClass](https://extendsclass.com/csv-generator.html) | Data generator tool for generating test data in CSV, SQL, XML, and JSON formats. |
+| [Faktuj](https://faktuj.pl) | Free online Polish VAT invoice generator API. Create, preview, and download professional PDF invoices. No registration or API key required. |
 | [FreeFlarum](https://freeflarum.com) | FreeFlarum is a free Flarum hosting service that allows users to quickly create and manage Flarum-based forums without the need for technical expertise or server management. |
+| [FreeKit](https://freekit.dev) | Free instant HTML hosting API. Upload HTML content and get a public URL. No authentication required. |
 | [IP.City](https://ip.city) | 100 free IP geo-location requests per day. |
 | [JSONing](https://jsoning.com/api) | Create a mock API from a JSON file for testing and prototyping. |
+| [LinkMeta](https://linkmeta.dev) | Free URL metadata extraction API. Retrieve Open Graph tags, meta descriptions, titles, and favicons from any URL. No API key required. |
+| [LinkShrink](https://linkshrink.dev) | Free privacy-first URL shortener API. Shorten URLs with no tracking, no ads, and no registration required. |
 | [Mockae](https://mockae.com) | Fake REST API powered by Lua. |
+| [OGForge](https://ogforge.dev) | Free Open Graph image generator API. Create dynamic OG images for social media sharing with customizable templates. No API key required. |
 | [OntarioNet CN Test](https://cntest.ontarionet.ca) | Check if a website is blocked in China by the Great Firewall. It identifies DNS pollution by comparing DNS results and ASN information detected by servers in China versus servers in the United States. |
+| [PageShot](https://pageshot.site) | Free screenshot and webpage capture API. Take full-page or viewport screenshots of any URL. No authentication required. |
 | [PDFBolt](https://pdfbolt.com) | Transform templates, HTML, or URLs into professional PDFs with our AI‑powered API. Free plan includes 100 documents/month. |
+| [PDFSpark](https://pdfspark.dev) | Free HTML and URL to PDF conversion API. Convert any webpage or HTML content into a downloadable PDF. No API key required. |
 | [Pythonium](https://pythonium.net/mockapy) | Create a mock API using a Python rule engine. |
+| [QRMint](https://qrmint.dev) | Free styled QR code generator API. Create customizable QR codes with colors, logos, and multiple output formats. No API key required. |
 | [Scraper's Proxy](https://scrapersproxy.com) | Simple HTTP proxy API made for scraping. Scrape anonymously without having to worry about restrictions, blocks, or captchas. First 100 successful scrapes per month free including JavaScript rendering (more are available if you contact support). |
 | [ScraperBox](https://scraperbox.com) | Undetectable web scraping API using real Chrome browsers and proxy rotation. Use a simple API call to scrape any web page. Free plan has 1000 requests per month. |
 | [ScrapingAnt](https://scrapingant.com) | Headless Chrome scraping API and free checked proxies service. JavaScript rendering, premium rotating proxies, CAPTCHAs avoiding. Free plans available. |


### PR DESCRIPTION
## Summary

Adds 8 free-forever developer API services from [SoftVoyagers](https://github.com/softvoyagers) to the **APIs, Data and ML** category:

| Service | Domain | Description |
|---------|--------|-------------|
| **Faktuj** | [faktuj.pl](https://faktuj.pl) | Free Polish VAT invoice generator |
| **FreeKit** | [freekit.dev](https://freekit.dev) | Free instant HTML hosting API |
| **LinkMeta** | [linkmeta.dev](https://linkmeta.dev) | Free URL metadata extraction API |
| **LinkShrink** | [linkshrink.dev](https://linkshrink.dev) | Free privacy-first URL shortener API |
| **OGForge** | [ogforge.dev](https://ogforge.dev) | Free Open Graph image generator API |
| **PageShot** | [pageshot.site](https://pageshot.site) | Free screenshot & webpage capture API |
| **PDFSpark** | [pdfspark.dev](https://pdfspark.dev) | Free HTML/URL to PDF conversion API |
| **QRMint** | [qrmint.dev](https://qrmint.dev) | Free styled QR code generator API |

All services are:
- **Free forever** — no paid tiers, no usage limits
- **No authentication required** — no API keys, no registration
- **Production-ready** — hosted on Azure, with public REST APIs

## Checklist
- [x] Services are not [disallowed services](https://github.com/wdhdev/free-for-life/blob/main/CONTRIBUTING.md#-disallowed-services)
- [x] Entries are in the correct category (APIs, Data and ML)
- [x] Entries are in alphabetical order
- [x] URLs have no trailing slash
- [x] Format matches: `| [Service](https://example.com) | Description. |`
- [x] Only the data file is modified (not README.md)