### PR TITLE
Add Temp Mail 24 to email tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ A huge list of great stuff you can get for free!
 | [AdGuard Temp Mail](https://adguard.com/en/adguard-temp-mail/overview.html) | Free temporary and disposable email generator. Keep your user data private and your inbox free of spam. |
 | [AnonAddy](https://anonaddy.com) | Open-source anonymous email forwarding, create unlimited email aliases for free. |
 | [Antideo](https://www.antideo.com) | 10 API requests per hour for email verification, IP, and phone number validation in the free tier. No credit cards required. |
+| [Temp Mail 24](https://temp-mail24.com/) | Free browser-based receive-only temporary inbox; no account required. |
 | [Bump](https://bump.email) | Free 10 Bump email addresses, 1 custom domain. |
 | [DKIM Validator](https://dkimvalidator.com) | Test if a domain's DNS/SPF/DKIM/DMARC settings are correct. |
 | [DuckDuckGo Email Protection](https://duckduckgo.com/email) | DuckDuckGo Email Protection is a free email forwarding service that removes multiple types of hidden email trackers and lets you create unlimited unique private email addresses on the fly. |


### PR DESCRIPTION
Adds Temp Mail 24 to the Email section with a factual description of the free, browser-based, receive-only inbox.