### PR TITLE
Add ItsPaint to Design and UI

### DIFF
--- a/data/Design_and_UI.md
+++ b/data/Design_and_UI.md
@@ -17,6 +17,7 @@
 | [Flowbite](https://flowbite.com) | A library of components built on top of the utility-classes from Tailwind CSS. |
 | [Haikei](https://haikei.app) | Haikei is a web app to generate stunning visual content – ready to use with your design tools and workflow. |
 | [Image and Video Compression](https://slingsite.github.io) | Unlimited free bulk compression of video and image for web use. For each device type, you will get all the modern formats for maximum performance and the legacy formats for compatibility. |
+| [ItsPaint](https://itspaintmac.com) | Free, open-source native macOS paint and screenshot markup app. Crop, annotate, add numbered step badges, pixelate, and export to 8 formats. |
 | [Lunacy](https://icons8.com/lunacy) | Free design software that keeps your flow with AI tools and built-in graphics. |
 | [MDBootstrap](https://mdbootstrap.com) | Free for personal & commercial use Bootstrap, Angular, React, and Vue UI Kits with over 700 components, stunning templates, 1-min installation, extensive tutorials & huge community. |
 | [Photopea](https://photopea.com) | A free and online alternative to Adobe Photoshop and support for the `.psd` file format. |


### PR DESCRIPTION
Adding ItsPaint to **Design and UI**, alphabetically, in `data/Design_and_UI.md`. I have not touched `README.md`, since it is generated from `/data`.

[ItsPaint](https://itspaintmac.com) is a free native macOS paint and screenshot markup app: a blank canvas at any size, crop, paste one image onto another, numbered step badges and pixelate for bug reports, background removal with no model, and eight export formats. MIT licensed, [source on GitHub](https://github.com/joshlin2201/itspaint), notarised, and free on the Mac App Store.

Free with no account, no trial, no upgrade tier and no telemetry. It also requests no network entitlement at all, so there is nothing in it that could phone home.

It is a desktop app rather than a website, on the same basis as the Lunacy entry already in this file. No trailing slash on the URL.
