### PR TITLE
Add Live Tennis API to APIs, Data and ML

### DIFF
--- a/data/APIs_Data_and_ML.md
+++ b/data/APIs_Data_and_ML.md
@@ -34,6 +34,7 @@
 | [IP.City](https://ip.city) | 100 free IP geo-location requests per day. |
 | [IPASIS](https://ipasis.com) | Real-time bot detection and fraud prevention API. Combines IP reputation, VPN/proxy/Tor detection, and email validation in a single API call. Free tier includes 1,000 requests/day with no credit card required. |
 | [JSONing](https://jsoning.com/api) | Create a mock API from a JSON file for testing and prototyping. |
+| [Live Tennis API](https://livetennisapi.com) | Live tennis scores, fixtures, and player data (including each player's current ranking) covering ATP, WTA, Challenger, and ITF. Free tier includes 30 requests/minute and 100 requests/day. |
 | [Mockae](https://mockae.com) | Fake REST API powered by Lua. |
 | [OntarioNet CN Test](https://cntest.ontarionet.ca) | Check if a website is blocked in China by the Great Firewall. It identifies DNS pollution by comparing DNS results and ASN information detected by servers in China versus servers in the United States. |
 | [PDFBolt](https://pdfbolt.com) | Transform templates, HTML, or URLs into professional PDFs with our AI‑powered API. Free plan includes 100 documents/month. |


### PR DESCRIPTION
Adds Live Tennis API (https://livetennisapi.com) to `data/APIs_Data_and_ML.md` in alphabetical order, URL without trailing slash. The free keyed tier (30 requests/minute, 100 requests/day — live scores, fixtures, player data) is free forever, not a trial.

Disclosure: I run the Live Tennis API, so this entry is vendor-authored — judge accordingly.