### PR TITLE
Add ArtboardLab to Design and UI

### DIFF
--- a/data/Design_and_UI.md
+++ b/data/Design_and_UI.md
@@ -3,6 +3,7 @@
 | Website | Description |
 |:-:|-|
 | [AI to UI](https://ai2ui.co) | Easily generate great looking UI components using artificial intelligence. Supports multiple frameworks including React, Next.js, and standard HTML. |
+| [ArtboardLab](https://artboardlab.com) | Free browser-based design tools including an Adobe Illustrator `.ai` viewer and `.ai` to SVG, PNG and PDF converters, plus image compression and format conversion. Files are processed in the browser and never uploaded, and no account is needed. |
 | [BeginThings](https://beginthings.com) | 96+ free browser-based tools for developers and freelancers — JSON formatter, Base64 encoder, image compressor, QR code generator, regex tester, and more. No login required. |
 | [Canva](https://canva.com) | Free online design tool to create visual content. |
 | [CodeMyUI](https://codemyui.com) | Handpicked collection of Web Design & UI Inspiration with Code Snippets. |


### PR DESCRIPTION
Adds one entry to **Design and UI**.

**Disclosure: I built this.**

Followed CONTRIBUTING: edited `data/Design_and_UI.md` rather than `README.md`, placed alphabetically between `AI to UI` and `BeginThings`, table format matched, and the URL has no trailing slash.

[ArtboardLab](https://artboardlab.com) is a set of free browser-based design tools. The part that isn't already covered by the list is Illustrator files: `.ai` files saved with "Create PDF Compatible File" carry a real PDF stream, so a viewer and `.ai` → SVG / PNG / PDF converters can run client-side without Illustrator installed — roughly the same role Photopea already fills here for `.psd`. The rest is image compression and format conversion (MozJPEG, OxiPNG, WebP, AVIF compiled to WebAssembly) plus a few print calculators.

Free with no account and no paid tier, everything runs in the browser, and nothing is uploaded. Not self-hosted, not 18+, finished and live. Happy to shorten the description if it runs long for the table.
